### PR TITLE
Return sunrise/sunset clock times spliced onto date parameter

### DIFF
--- a/sunrisesunset.go
+++ b/sunrisesunset.go
@@ -417,9 +417,8 @@ func GetSunriseSunset(latitude float64, longitude float64, utcOffset float64, da
 	sunsetSeconds := minIndex(abs(tempSunset))
 
 	// Convert the seconds to time
-	defaultTime := new(time.Time)
-	sunrise = defaultTime.Add(time.Duration(sunriseSeconds) * time.Second)
-	sunset = defaultTime.Add(time.Duration(sunsetSeconds) * time.Second)
+	sunrise = time.Date(date.Year(), date.Month(), date.Day(), 0, 0, sunriseSeconds, 0, date.Location())
+	sunset = time.Date(date.Year(), date.Month(), date.Day(), 0, 0, sunsetSeconds, 0, date.Location())
 
 	return
 }

--- a/sunrisesunset_test.go
+++ b/sunrisesunset_test.go
@@ -64,10 +64,10 @@ func TestGetSunriseSunset(t *testing.T) {
 		sunrise   time.Time
 		sunset    time.Time
 	}{
-		{-23.545570, -46.704082, -3.0, date, time.Date(1, 1, 1, 6, 11, 44, 0, time.UTC), time.Date(1, 1, 1, 18, 14, 27, 0, time.UTC)}, // Sao Paulo - Brazil
-		{36.7201600, -4.4203400, 1.0, date, time.Date(1, 1, 1, 7, 16, 45, 0, time.UTC), time.Date(1, 1, 1, 19, 32, 10, 0, time.UTC)},  // Málaga - Spain
-		{28.613084, 77.209168, 5.5, date, time.Date(1, 1, 1, 6, 21, 45, 0, time.UTC), time.Date(1, 1, 1, 18, 34, 07, 0, time.UTC)},    // Nova Delhi - India
-		{32.755701, -96.797296, -5.0, date, time.Date(1, 1, 1, 7, 26, 34, 0, time.UTC), time.Date(1, 1, 1, 19, 41, 07, 0, time.UTC)},  // Dallas - USA
+		{-23.545570, -46.704082, -3.0, date, time.Date(2017, 3, 23, 6, 11, 44, 0, time.UTC), time.Date(2017, 3, 23, 18, 14, 27, 0, time.UTC)}, // Sao Paulo - Brazil
+		{36.7201600, -4.4203400, 1.0, date, time.Date(2017, 3, 23, 7, 16, 45, 0, time.UTC), time.Date(2017, 3, 23, 19, 32, 10, 0, time.UTC)},  // Málaga - Spain
+		{28.613084, 77.209168, 5.5, date, time.Date(2017, 3, 23, 6, 21, 45, 0, time.UTC), time.Date(2017, 3, 23, 18, 34, 07, 0, time.UTC)},    // Nova Delhi - India
+		{32.755701, -96.797296, -5.0, date, time.Date(2017, 3, 23, 7, 26, 34, 0, time.UTC), time.Date(2017, 3, 23, 19, 41, 07, 0, time.UTC)},  // Dallas - USA
 	}
 
 	// Test with all values in the table


### PR DESCRIPTION
## Change

Reuses the date parameter's year, month, day, and location in the output times instead of indicating the times on the date 1/1/1 in UTC (from `new(time.Time)`).

## Motivation

Fix #1. As that issue points out, it's hard to compare sunrise/sunset times on 1/1/1 to the input date using Go's date comparators.

To check if a time is before or after its local sunset, one has to use this library, extract clock time from its outputs, and then recompose it into a date. [Here's my usage in `daylight`.](https://github.com/lukasschwab/daylight/blob/b4325565c4aaa57faa3510a5e07452ea61d01d99/data.go#L61-L74)

## Testing

+ Updated the existing unit tests accordingly. `go test` passes.
+ Checked an input date outside of UTC, in San Francisco, CA; the output was as expected: `2021-02-17 17:51:20 -0800 PST`.